### PR TITLE
Set disable large txn ops to on

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,7 @@ option(LOGGING_EN "Enable debug logging" OFF)
 option(PERF_LOGGING_EN "Enable performance logging" OFF)
 option(ENABLE_DD_PYTHON "Enable building the Python library" OFF)
 option(XRT_RUNLIST_EN "Enable xrt experimental runlist feature" OFF)
-option(DISABLE_LARGE_TXN_OPS "Disable large txn binaries in the package" OFF)
+option(DISABLE_LARGE_TXN_OPS "Disable large txn binaries in the package" ON)
 
 if(ENABLE_SIMNOWLITE_BUILD)
   add_definitions(-DSIMNOWLITE_EN)


### PR DESCRIPTION
# Summary of Changes

Set disable large txn ops to on

# Motivation

it would generate a really large DLL if not OFF.

# Implementation

N/A
